### PR TITLE
bill split handler and transaction logic

### DIFF
--- a/src/bots/telegram/auth.py
+++ b/src/bots/telegram/auth.py
@@ -203,11 +203,15 @@ async def handle_signup_confirm(
 
 
 async def get_user(
-    update: Optional[Update] = None, token: Optional[str] = None
+    update: Optional[Update] = None,
+    token: Optional[str] = None,
+    tg_user_id=None,
 ) -> Any:
     """Get user data from the token."""
     if token:
         return await telegram_collection.find_one({"token": token})
+    if tg_user_id:
+        return await telegram_collection.find_one({"telegram_id": tg_user_id})
     if update:
         user_id = update.effective_user.id
         print(f"User ID: {user_id}")
@@ -226,9 +230,14 @@ def authenticate(func):
             return await func(
                 update, context, token=user.get("token"), *args, **kwargs
             )
-        await update.message.reply_text(
-            "Please /login or /signup to continue."
-        )
+        if update.effective_chat.type != "private":
+            await update.message.reply_text(
+                "Please sign in to your private chat with the bot to continue."
+            )
+        else:
+            await update.message.reply_text(
+                "Please /login or /signup to continue."
+            )
         return ConversationHandler.END
 
     return wrapper

--- a/src/bots/telegram/group_bill_split.py
+++ b/src/bots/telegram/group_bill_split.py
@@ -43,7 +43,8 @@ async def bill_split_entry(
         keyboard = [
             [
                 InlineKeyboardButton(
-                    f"Confirm - {user}", callback_data=f"confirm_{user}"
+                    f"Confirm - {user}",
+                    callback_data=f"confirm_bill_split_{user}",
                 )
             ]
             for user in mentioned_users
@@ -67,6 +68,15 @@ async def confirm_bill_split(
     mentioned_username = query.data.split("_", 1)[
         1
     ]  # Extract mentioned username
+
+    mmuser = await get_user(tg_user_id=user.id)
+    if not mmuser:
+        await query.answer(
+            "You need to be authenticated to confirm. Please send `/login` or `/signup` in private chat with the bot."
+        )
+        return
+
+    print(mmuser)
 
     # todo : Store the confirmation in a context
     if "confirmed_users" not in context.chat_data:

--- a/src/bots/telegram/group_bill_split.py
+++ b/src/bots/telegram/group_bill_split.py
@@ -1,3 +1,6 @@
+from typing import Dict, List
+
+from loguru import logger
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
@@ -17,14 +20,33 @@ from bots.telegram.auth import authenticate, get_user
 from bots.telegram.utils import cancel, extract_mentioned_usernames
 
 
+class BillSplitTransaction:
+    def __init__(self, mmuser_names: List[str], amount: float = None):
+        self.confirmed_states = {name: False for name in mmuser_names}
+        self.amount = amount
+
+
+ONGOING_BILL_SPLIT_TRANSACTIONS = {
+    int: BillSplitTransaction
+}  # Dictionary to track ongoing transactions, group_id: BillSplitTransaction
+
+
 @authenticate
 async def bill_split_entry(
     update: Update, context: ContextTypes.DEFAULT_TYPE, token: str
 ) -> None:
     """Handle the /bill_split command."""
+    group_id = update.message.chat_id
 
-    mentioned_users = await extract_mentioned_usernames(update, context)
-    # remove the bot itself from the list of mentioned users
+    if group_id in ONGOING_BILL_SPLIT_TRANSACTIONS:
+        await update.message.reply_text(
+            "A bill split is already in progress in this group. Please complete or cancel it before starting a new one."
+        )
+        return
+
+    mentioned_users = await extract_mentioned_usernames(
+        update, context, keep_at_symbol=False
+    )
     mentioned_users = [
         user for user in mentioned_users if user != f"@{context.bot.username}"
     ]
@@ -34,12 +56,66 @@ async def bill_split_entry(
             "Please mention the users to split the bill with."
         )
         return
-    else:
-        await update.message.reply_text(
-            f"Users that will be included in the bill split: {', '.join(mentioned_users)}"
-        )
 
-        # Create inline keyboard buttons for each mentioned user
+    # Create a new bill split transaction
+    ONGOING_BILL_SPLIT_TRANSACTIONS[group_id] = BillSplitTransaction(
+        mentioned_users
+    )
+
+    await update.message.reply_text(
+        f"Users that will be included in the bill split: {', '.join(mentioned_users)}"
+    )
+
+    # ask for amount
+    amount_message = await update.message.reply_text(
+        "Please tell me the amount to be split by replying to this message."
+    )
+
+    context.chat_data["amount_request_message_id"] = amount_message.message_id
+    return  # Wait for user response before proceeding
+
+
+async def bill_split_amount_handler(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Handle user input for bill amount if it is a reply to the request."""
+    group_id = update.message.chat_id
+
+    logger.debug(
+        f"Group ID: {group_id} - Message ID: {update.message.message_id}"
+    )
+
+    if group_id not in ONGOING_BILL_SPLIT_TRANSACTIONS:
+        await update.message.reply_text(
+            "No active bill split transaction in this group."
+        )
+        return
+
+    if (
+        update.message.reply_to_message
+        and update.message.reply_to_message.message_id
+        == context.chat_data.get("amount_request_message_id")
+    ):
+        amount_text = update.message.text
+        try:
+            amount = float(amount_text)
+        except ValueError:
+            await update.message.reply_text(
+                "Invalid amount. Please enter a valid number."
+            )
+
+        ONGOING_BILL_SPLIT_TRANSACTIONS[group_id].amount = amount
+        await update.message.reply_text(
+            f"The bill amount is set to {amount:.2f}. Now waiting for confirmations."
+        )
+        mentioned_users = list(
+            ONGOING_BILL_SPLIT_TRANSACTIONS[group_id].confirmed_states.keys()
+        )
+        if not mentioned_users:
+            await update.message.reply_text(
+                "No users mentioned for the bill split."
+            )
+            return
         keyboard = [
             [
                 InlineKeyboardButton(
@@ -50,24 +126,40 @@ async def bill_split_entry(
             for user in mentioned_users
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
-
-        # Send message with inline keyboard
         await update.message.reply_text(
             "Each mentioned user, please confirm your participation by clicking the button below:",
             reply_markup=reply_markup,
         )
 
 
-# Callback handler for button clicks
 async def confirm_bill_split(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Handle confirmation button clicks."""
     query = update.callback_query
-    user = query.from_user  # The user who clicked the button
-    mentioned_username = query.data.split("_", 1)[
-        1
-    ]  # Extract mentioned username
+    user = query.from_user
+    mentioned_username = query.data.split("_", 1)[1].removeprefix(
+        "bill_split_"
+    )
+    group_id = query.message.chat_id
+
+    if group_id not in ONGOING_BILL_SPLIT_TRANSACTIONS:
+        await query.answer("No active bill split transaction in this group.")
+        return
+
+    transaction = ONGOING_BILL_SPLIT_TRANSACTIONS[group_id]
+
+    # logger.debug(
+    #     f"User: {user.username} tried to confirm bill split for {mentioned_username}, the states are {transaction.confirmed_states}"
+    # )
+
+    if user.username != mentioned_username:
+        await query.answer("You can only confirm your own participation.")
+        return
+
+    if mentioned_username not in transaction.confirmed_states:
+        await query.answer("You are not part of this bill split.")
+        return
 
     mmuser = await get_user(tg_user_id=user.id)
     if not mmuser:
@@ -76,19 +168,33 @@ async def confirm_bill_split(
         )
         return
 
-    print(mmuser)
+    transaction.confirmed_states[mentioned_username] = True
 
-    # todo : Store the confirmation in a context
-    if "confirmed_users" not in context.chat_data:
-        context.chat_data["confirmed_users"] = {}
-    context.chat_data["confirmed_users"][mentioned_username] = user.id
-    # todo : after all users confirm, proceed with the bill split logic
-
-    # Acknowledge the button press
     await query.answer(f"Confirmed: {mentioned_username}")
 
-    # Notify the group or update the message
-    # todo : Notify the bill split creator or the group, this requires a bill split pull to manage it per group
-    await query.edit_message_text(
-        f"{mentioned_username} has confirmed participation!"
+    # Update button states by removing the confirmed user
+    updated_keyboard = [
+        [
+            InlineKeyboardButton(
+                f"Confirm - {user}", callback_data=f"confirm_bill_split_{user}"
+            )
+        ]
+        for user, confirmed in transaction.confirmed_states.items()
+        if not confirmed  # Only keep buttons for users who haven't confirmed
+    ]
+
+    reply_markup = (
+        InlineKeyboardMarkup(updated_keyboard) if updated_keyboard else None
     )
+
+    await query.edit_message_text(
+        f"{mentioned_username} has confirmed participation!",
+        reply_markup=reply_markup,
+    )
+
+    if all(transaction.confirmed_states.values()):
+        await query.message.reply_text(
+            "All users have confirmed. Proceeding with bill split."
+        )
+        # todo : proceed with all user's personal account
+        del ONGOING_BILL_SPLIT_TRANSACTIONS[group_id]

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -82,7 +82,7 @@ async def group_chat_handler(
 
     print(
         f"User: {user.username} mentioned the bot in group chat: {chat.title}, message: {text}"
-    )
+    )  # todo : remove this line after testing
 
     # if is menu command
     if "/menu" in text:
@@ -115,7 +115,9 @@ def main() -> None:
         MessageHandler(filters.ChatType.GROUP, group_chat_handler)
     )
     application.add_handler(
-        CallbackQueryHandler(confirm_bill_split, pattern="^confirm_")
+        CallbackQueryHandler(
+            confirm_bill_split, pattern="^confirm_bill_split_"
+        )
     )
 
     # Register private chat handlers

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -22,7 +22,11 @@ from bots.telegram.analytics import analytics_handlers
 from bots.telegram.auth import auth_handlers, get_user  # Update import
 from bots.telegram.categories import categories_handlers
 from bots.telegram.expenses import expenses_handlers
-from bots.telegram.group_bill_split import bill_split_entry, confirm_bill_split
+from bots.telegram.group_bill_split import (
+    bill_split_amount_handler,
+    bill_split_entry,
+    confirm_bill_split,
+)
 from bots.telegram.receipts import receipts_handlers  # New import
 from bots.telegram.utils import (
     get_group_chat_menu_commands,
@@ -75,6 +79,12 @@ async def group_chat_handler(
     chat = update.message.chat
     user = update.message.from_user
     text = update.message.text
+
+    # if its a reply message
+    if update.message.reply_to_message:
+        await bill_split_amount_handler(
+            update, context
+        )  # todo : manage all reply handling with pool
 
     # Check if the bot is mentioned in the message
     if not context.bot.username in text:

--- a/src/bots/telegram/utils.py
+++ b/src/bots/telegram/utils.py
@@ -88,7 +88,9 @@ def parse_menu_commands(text: str) -> str:
 
 
 async def extract_mentioned_usernames(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    keep_at_symbol: bool = True,
 ) -> List[str]:
     """Handles group messages where the bot is mentioned and extracts @mentions."""
     message = update.message
@@ -103,6 +105,8 @@ async def extract_mentioned_usernames(
                 username = message.text[
                     entity.offset : entity.offset + entity.length
                 ]
+                if not keep_at_symbol:
+                    username = username[1:]
                 mentioned_users.append(username)
 
     return mentioned_users


### PR DESCRIPTION
## Description

added bill split handler and transaction logic

## Related Issue
Closes #32 , #31 

## Type of Change
- [x] New feature
- [x] Enhancement


## Screenshots/Logs

![image](https://github.com/user-attachments/assets/58aa9319-4dff-4da6-ad39-3b03b8f48a67)

Note: the bot kept itself in bill split just for a showcase that I cannot confirm others, it removes itself in code actually.

## Additional Notes

Behavior of Bill Split Command (`/bill_split`): 

The `/bill_split` command is a group command that facilitates bill-splitting among group members. The process follows these steps:

1. **Command Initiation**  
   - A user initiates the bill split by using `/bill_split` and mentioning users in the message.
   - The bot verifies if a bill split is already active in the group. If so, it prompts users to complete or cancel it before starting a new one.

2. **User Selection**  
   - The bot extracts the mentioned users (excluding itself) and confirms their participation.
   - If no users are mentioned, it prompts the initiator to mention at least one user.

3. **Amount Input**  
   - The bot requests the bill amount by asking users to reply to the message with a numeric value.
   - It validates the input to ensure it's a valid number.

4. **User Confirmation**  
   - Once the amount is set, the bot generates confirmation buttons for each mentioned user.
   - Users must click their respective buttons to confirm participation.
   - If a user attempts to confirm for someone else, the bot denies the action.

5. **Authentication Requirement**  
   - Each participant must be authenticated (via `/login` or `/signup` in private chat) to confirm their participation.

6. **Completion**  
   - Once all users confirm, the bot finalizes the bill split process.
   - The ongoing transaction is then removed from the tracking system.

7. **Edge Cases & Error Handling**  
   - If an unmentioned user attempts to confirm, the bot denies their request.
   - If a participant is not authenticated, they are prompted to authenticate before confirming.
   - The bot ensures only the remaining users see confirmation buttons, preventing accidental re-confirmations.
