### PR TITLE
added reply handling pool in group chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 - [Money Manager](#money-manager)
   - [👥 Functionality](#-functionality)
-  - [👨‍💻 Developer Friendly](#%E2%80%8D-developer-friendly)
-  - [🛠️ Installation and Dev](#-installation-and-dev)
-  - [👨‍💻 Screenshots of Functionalities](#%E2%80%8D-screenshots-of-functionalities)
+  - [👨‍💻 Developer Friendly](#-developer-friendly)
+  - [🛠️ Installation and Dev](#️-installation-and-dev)
+  - [👨‍💻 Screenshots of Functionalities](#-screenshots-of-functionalities)
   - [🤝 Contributing](#-contributing)
   - [📜 Code of Conduct](#-code-of-conduct)
 

--- a/src/bots/telegram/accounts.py
+++ b/src/bots/telegram/accounts.py
@@ -13,7 +13,7 @@ from telegram.ext import (
 from telegram_bot_pagination import InlineKeyboardPaginator
 
 from bots.telegram.auth import authenticate
-from bots.telegram.utils import cancel
+from bots.telegram.utils import private_chat_cancel
 from config.config import TELEGRAM_BOT_API_BASE_URL
 
 # Constants
@@ -468,7 +468,7 @@ accounts_conv_handler = ConversationHandler(
         ],
         SELECT_CURRENCY: [CallbackQueryHandler(handle_currency_selection)],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add new conversation handler
@@ -477,7 +477,7 @@ accounts_delete_conv_handler = ConversationHandler(
     states={
         CONFIRM_DELETE: [CallbackQueryHandler(confirm_delete_account)],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Update the accounts_update_conv_handler
@@ -497,7 +497,7 @@ accounts_update_conv_handler = ConversationHandler(
             )
         ],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Update the handlers list

--- a/src/bots/telegram/analytics.py
+++ b/src/bots/telegram/analytics.py
@@ -19,7 +19,7 @@ from telegram.ext import (
 )
 
 from bots.telegram.auth import authenticate
-from bots.telegram.utils import cancel
+from bots.telegram.utils import private_chat_cancel
 from config.config import (
     GMAIL_SMTP_PASSWORD,
     GMAIL_SMTP_PORT,
@@ -634,7 +634,7 @@ analytics_handlers.extend(
                     )
                 ],
             },
-            fallbacks=[CommandHandler("cancel", cancel)],
+            fallbacks=[CommandHandler("cancel", private_chat_cancel)],
         )
     ]
 )

--- a/src/bots/telegram/auth.py
+++ b/src/bots/telegram/auth.py
@@ -13,7 +13,10 @@ from telegram.ext import (
     filters,
 )
 
-from bots.telegram.utils import cancel, get_private_chat_menu_commands
+from bots.telegram.utils import (
+    get_private_chat_menu_commands,
+    private_chat_cancel,
+)
 from config import config
 
 # Constants
@@ -272,7 +275,7 @@ auth_handlers = [
                 )
             ],
         },
-        fallbacks=[CommandHandler("cancel", cancel)],
+        fallbacks=[CommandHandler("cancel", private_chat_cancel)],
     ),
     ConversationHandler(
         entry_points=[CommandHandler("signup", signup)],
@@ -293,7 +296,7 @@ auth_handlers = [
                 )
             ],
         },
-        fallbacks=[CommandHandler("cancel", cancel)],
+        fallbacks=[CommandHandler("cancel", private_chat_cancel)],
     ),
     CommandHandler("logout", logout),
 ]

--- a/src/bots/telegram/categories.py
+++ b/src/bots/telegram/categories.py
@@ -13,7 +13,7 @@ from telegram.ext import (
 from telegram_bot_pagination import InlineKeyboardPaginator
 
 from bots.telegram.auth import authenticate
-from bots.telegram.utils import cancel
+from bots.telegram.utils import private_chat_cancel
 from config.config import TELEGRAM_BOT_API_BASE_URL
 
 # Constants
@@ -369,7 +369,7 @@ categories_conv_handler = ConversationHandler(
             )
         ],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add new conversation handler
@@ -378,7 +378,7 @@ categories_delete_conv_handler = ConversationHandler(
     states={
         CONFIRM_DELETE: [CallbackQueryHandler(confirm_delete_category)],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add new conversation handler for updates
@@ -392,7 +392,7 @@ categories_update_conv_handler = ConversationHandler(
             )
         ],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Update the handlers list

--- a/src/bots/telegram/expenses.py
+++ b/src/bots/telegram/expenses.py
@@ -17,7 +17,7 @@ from telegram_bot_calendar import DetailedTelegramCalendar
 from telegram_bot_pagination import InlineKeyboardPaginator
 
 from bots.telegram.auth import authenticate
-from bots.telegram.utils import cancel
+from bots.telegram.utils import private_chat_cancel
 from config.config import MONGO_URI, TELEGRAM_BOT_API_BASE_URL, TIME_ZONE
 
 # Constants
@@ -825,7 +825,7 @@ expenses_conv_handler = ConversationHandler(
         DATE_OPTION: [CallbackQueryHandler(handle_date_option)],
         DATE: [CallbackQueryHandler(date)],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add the new handlers
@@ -839,7 +839,7 @@ expenses_delete_conv_handler = ConversationHandler(
             CallbackQueryHandler(confirm_delete),
         ],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add the delete all conversation handler
@@ -848,7 +848,7 @@ expenses_delete_all_conv_handler = ConversationHandler(
     states={
         DELETE_ALL_CONFIRM: [CallbackQueryHandler(confirm_delete_all)],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Add this new conversation handler at the bottom with other handlers
@@ -871,7 +871,7 @@ expenses_update_conv_handler = ConversationHandler(
             CallbackQueryHandler(handle_update_value),
         ],
     },
-    fallbacks=[CommandHandler("cancel", cancel)],
+    fallbacks=[CommandHandler("cancel", private_chat_cancel)],
 )
 
 # Handlers for expenses

--- a/src/bots/telegram/group_bill_split.py
+++ b/src/bots/telegram/group_bill_split.py
@@ -17,7 +17,8 @@ from telegram.ext import (
 )
 
 from bots.telegram.auth import authenticate, get_user
-from bots.telegram.utils import cancel, extract_mentioned_usernames
+from bots.telegram.reply_handlers import ReplyWaiters
+from bots.telegram.utils import extract_mentioned_usernames
 
 
 class BillSplitTransaction:
@@ -48,7 +49,7 @@ async def bill_split_entry(
         update, context, keep_at_symbol=False
     )
     mentioned_users = [
-        user for user in mentioned_users if user != f"@{context.bot.username}"
+        user for user in mentioned_users if user != f"{context.bot.username}"
     ]
 
     if not mentioned_users:
@@ -72,6 +73,9 @@ async def bill_split_entry(
     )
 
     context.chat_data["amount_request_message_id"] = amount_message.message_id
+    ReplyWaiters[
+        (group_id, amount_message.message_id)
+    ] = bill_split_amount_handler
     return  # Wait for user response before proceeding
 
 

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -28,6 +28,7 @@ from bots.telegram.group_bill_split import (
     confirm_bill_split,
 )
 from bots.telegram.receipts import receipts_handlers  # New import
+from bots.telegram.reply_handlers import reply_handler
 from bots.telegram.utils import (
     get_group_chat_menu_commands,
     get_private_chat_menu_commands,
@@ -82,9 +83,8 @@ async def group_chat_handler(
 
     # if its a reply message
     if update.message.reply_to_message:
-        await bill_split_amount_handler(
-            update, context
-        )  # todo : manage all reply handling with pool
+        # get chat id and message id of the replied message
+        await reply_handler(update=update, context=context)
 
     # Check if the bot is mentioned in the message
     if not context.bot.username in text:

--- a/src/bots/telegram/reply_handlers.py
+++ b/src/bots/telegram/reply_handlers.py
@@ -1,0 +1,94 @@
+from typing import Callable, Tuple
+
+from loguru import logger
+from telegram import Update
+from telegram.ext import (
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
+
+
+class ReplyWaiters:
+    """
+    A class to manage reply waiters for Telegram bot messages.
+    """
+
+    def __init__(self):
+        self.waiters = {
+            Tuple[int, int]: Callable
+        }  # Dictionary to store waiters
+
+    def __getitem__(self, key):
+        """
+        Get the callback function for a specific chat and message ID.
+
+        :param key: A tuple containing the chat ID and message ID.
+        :return: The callback function associated with the key.
+        """
+        return self.waiters.get(key)
+
+    def __setitem__(self, key, value):
+        """
+        Set the callback function for a specific chat and message ID.
+
+        :param key: A tuple containing the chat ID and message ID.
+        :param value: The callback function to be associated with the key.
+        """
+        self.waiters[key] = value
+
+    def __delitem__(self, key):
+        """
+        Delete the callback function for a specific chat and message ID.
+
+        :param key: A tuple containing the chat ID and message ID.
+        """
+        if key in self.waiters:
+            del self.waiters[key]
+
+    def keys(self):
+        """
+        Get all keys in the waiters dictionary.
+
+        :return: A list of keys in the waiters dictionary.
+        """
+        return self.waiters.keys()
+
+    def items(self):
+        """
+        Get all items in the waiters dictionary.
+
+        :return: A list of items in the waiters dictionary.
+        """
+        return self.waiters.items()
+
+
+ReplyWaiters = ReplyWaiters()  # singleton
+
+
+async def reply_handler(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """
+    Handle replies to messages in the Telegram bot.
+
+    :param update: The update containing the message.
+    :param context: The context of the update.
+    """
+    chat_id = update.message.reply_to_message.chat.id
+    message_id = update.message.reply_to_message.message_id
+
+    logger.debug(
+        f"Chat ID: {chat_id} - Reply to Message ID: {message_id}"
+    )  # todo : remove this line after testing
+
+    if (chat_id, message_id) in ReplyWaiters.keys():
+        await ReplyWaiters[(chat_id, message_id)](update, context)
+        del ReplyWaiters[(chat_id, message_id)]
+    # else:
+    #     await update.message.reply_text("This message is not waiting for a reply.")
+    return ConversationHandler.END

--- a/src/bots/telegram/utils.py
+++ b/src/bots/telegram/utils.py
@@ -12,7 +12,9 @@ from config.config import (
 )
 
 
-async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def private_chat_cancel(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Cancel current conversation and clear user data.
 
     Args:
@@ -110,3 +112,16 @@ async def extract_mentioned_usernames(
                 mentioned_users.append(username)
 
     return mentioned_users
+
+
+class Singleton(type):
+    """A metaclass for creating singleton classes."""
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs
+            )
+        return cls._instances[cls]


### PR DESCRIPTION
## added reply handling pool in group chat

Now, replies to messages are handled by a pool. Reason: In private chat, the bot assumes the next message will be the reply of the previous message, and the handlers are designed in a bot-ask-user-input manner. However, in group chat, the next message after the bot asks for some question might be other users chatting or replying to something else.

## Related Issue
Closes #36 

## Type of Change
- [x] New feature
- [x] Enhancement


## Screenshots

![image](https://github.com/user-attachments/assets/6c7d1fd4-1ec1-440e-b07c-4835d9a7c1ee)

