### PR TITLE
Fix users other than issuer of bill split can specify amount

### DIFF
--- a/src/bots/telegram/auth.py
+++ b/src/bots/telegram/auth.py
@@ -217,7 +217,6 @@ async def get_user(
         return await telegram_collection.find_one({"telegram_id": tg_user_id})
     if update:
         user_id = update.effective_user.id
-        print(f"User ID: {user_id}")
         return await telegram_collection.find_one({"telegram_id": user_id})
 
 

--- a/src/bots/telegram/group_bill_split.py
+++ b/src/bots/telegram/group_bill_split.py
@@ -103,10 +103,11 @@ async def bill_split_amount_handler(
         amount_text = update.message.text
         try:
             amount = float(amount_text)
-        except ValueError:
+        except ValueError as e:
             await update.message.reply_text(
                 "Invalid amount. Please enter a valid number."
             )
+            raise e  # raise to external handler
 
         ONGOING_BILL_SPLIT_TRANSACTIONS[group_id].amount = amount
         await update.message.reply_text(

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -25,7 +25,7 @@ from bots.telegram.expenses import expenses_handlers
 from bots.telegram.group_bill_split import (
     bill_split_amount_handler,
     bill_split_entry,
-    confirm_bill_split,
+    confirm_bill_split_callback_handler,
 )
 from bots.telegram.receipts import receipts_handlers  # New import
 from bots.telegram.reply_handlers import reply_handler
@@ -101,7 +101,7 @@ async def group_chat_handler(
     # if is unknown command
     else:
         await update.message.reply_text(
-            f"Hello {user.first_name}, I saw you mentioned me in {chat.title}! If you need help, type /menu."
+            f"Hello {user.first_name}, I saw you mentioned me in {chat.title}! If you need help, please mention me with command /menu for available commands."
         )
         return
 
@@ -122,7 +122,7 @@ def main() -> None:
     )
     application.add_handler(
         CallbackQueryHandler(
-            confirm_bill_split, pattern="^confirm_bill_split_"
+            confirm_bill_split_callback_handler, pattern="^confirm_bill_split_"
         )
     )
 

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -90,10 +90,6 @@ async def group_chat_handler(
     if not context.bot.username in text:
         return
 
-    print(
-        f"User: {user.username} mentioned the bot in group chat: {chat.title}, message: {text}"
-    )  # todo : remove this line after testing
-
     # if is menu command
     if "/menu" in text:
         await update.message.reply_text(get_group_chat_menu_commands())

--- a/src/bots/telegram/reply_handlers.py
+++ b/src/bots/telegram/reply_handlers.py
@@ -1,3 +1,4 @@
+from functools import cache
 from typing import Callable, Tuple
 
 from loguru import logger
@@ -87,8 +88,12 @@ async def reply_handler(
     )  # todo : remove this line after testing
 
     if (chat_id, message_id) in ReplyWaiters.keys():
-        await ReplyWaiters[(chat_id, message_id)](update, context)
-        del ReplyWaiters[(chat_id, message_id)]
+        try:
+            await ReplyWaiters[(chat_id, message_id)](update, context)
+            del ReplyWaiters[(chat_id, message_id)]
+        except Exception as e:
+            logger.error(f"Error in reply handler: {e}")
+
     # else:
     #     await update.message.reply_text("This message is not waiting for a reply.")
     return ConversationHandler.END

--- a/src/config/config_sample.py
+++ b/src/config/config_sample.py
@@ -49,6 +49,7 @@ cancel - To cancel any operation
 
 TELEGRAM_GROUP_CHAT_COMMAND_TEXT = """
 menu - Display available commands
+bill_split - Split a bill with group members
 """
 
 GMAIL_SMTP_SERVER = os.getenv("GMAIL_SMTP_SERVER", "smtp.gmail.com")


### PR DESCRIPTION
## Description

Fixed users other than issuer of bill split can specify amount during `\bill_split` in group chat

## Related Issue
Closes #38 

## Type of Change
- [x] Bug fix

## Screenshots

![image](https://github.com/user-attachments/assets/22be1217-0c92-4733-8211-b10d9e405e8d)

