### PR TITLE
added cancel bill split in group

### DIFF
--- a/src/bots/telegram/group_bill_split.py
+++ b/src/bots/telegram/group_bill_split.py
@@ -303,3 +303,30 @@ async def confirm_bill_split_callback_handler(
             )
 
         del ONGOING_BILL_SPLIT_TRANSACTIONS[group_id]
+
+
+async def cancel_bill_split_handler(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Cancel the bill split process."""
+    group_id = update.message.chat_id
+
+    if group_id in ONGOING_BILL_SPLIT_TRANSACTIONS:
+        # check if the issuer of cancel command is the same user who initiated the bill split
+        if (
+            update.message.from_user.id
+            != ONGOING_BILL_SPLIT_TRANSACTIONS[group_id].issuer["telegram_id"]
+        ):
+            await update.message.reply_text(
+                "You are not the issuer of this bill split."
+            )
+            return
+
+        del ONGOING_BILL_SPLIT_TRANSACTIONS[group_id]
+        await update.message.reply_text(
+            "Bill split process has been canceled."
+        )
+    else:
+        await update.message.reply_text(
+            "No active bill split transaction to cancel."
+        )

--- a/src/bots/telegram/main.py
+++ b/src/bots/telegram/main.py
@@ -25,6 +25,7 @@ from bots.telegram.expenses import expenses_handlers
 from bots.telegram.group_bill_split import (
     bill_split_amount_handler,
     bill_split_entry,
+    cancel_bill_split_handler,
     confirm_bill_split_callback_handler,
 )
 from bots.telegram.receipts import receipts_handlers  # New import
@@ -97,6 +98,10 @@ async def group_chat_handler(
     # if is bill split command
     elif "/bill_split" in text:
         await bill_split_entry(update, context)
+        return
+    # if is cancel command
+    elif "/cancel" in text:
+        await cancel_bill_split_handler(update, context)
         return
     # if is unknown command
     else:


### PR DESCRIPTION
## Description

Now `/cancel` cancels ongoing group bill split, it must be issued by the bill split issuer

## Related Issue
Closes #34 

## Type of Change
- [x] New feature
- [x] Enhancement

## Screenshots

![image](https://github.com/user-attachments/assets/a99e675d-8dff-4d4c-8a22-e31fad7a35d3)

